### PR TITLE
update config for Animated timing

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,14 +167,14 @@ class SimplePicker extends Component {
 		});
     Animated.timing(
       this.state.translateY,
-      { toValue: Platform.OS === 'ios' ? -250 : -85 }
+      { toValue: Platform.OS === 'ios' ? -250 : -85, useNativeDriver: true, }
     ).start();
 	}
 
 	hide() {
     Animated.timing(
       this.state.translateY,
-      { toValue: 0 }
+      { toValue: 0, useNativeDriver: true, }
     ).start(() => this.setState({ modalVisible: false }));
 	}
 


### PR DESCRIPTION
Solve an issue with react-native:
Animated: `useNativeDriver` was not specified. This is a required option and must be explicitly set to `true` or `false`